### PR TITLE
fix: Relax python-telegram-bot version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-telegram-bot==21.0.1
+python-telegram-bot~=21.0
 python-dotenv


### PR DESCRIPTION
This commit updates the `requirements.txt` file to use a more flexible version specifier (`~=21.0`) for `python-telegram-bot`.

The previously pinned version (`21.0.1`) caused a `TypeError: cannot create weak reference to 'Application' object` on some Python versions (like 3.13) when using persistence.

Using a tilde requirement allows pip to install newer, compatible versions of the library (e.g., 21.9) where this bug is fixed, resolving the runtime error for the user.